### PR TITLE
fix husky - .git can't be found error

### DIFF
--- a/jellyseerr.sh
+++ b/jellyseerr.sh
@@ -38,7 +38,7 @@ function _jellyseerr_install() {
         echo "Download failed"
         exit 1
     }
-    mkdir -p $HOME/jellyseerr
+    mkdir -p $HOME/jellyseerr/.git
     tar --strip-components=1 -C $HOME/jellyseerr -xzvf /home/${user}/jellyseerr.tar.gz >> "$log" 2>&1
     rm /home/${user}/jellyseerr.tar.gz
     echo "Code extracted"


### PR DESCRIPTION
As of a discord user reporting an error we tried to find a fix for:

```
$ husky install
husky - .git can't be found (see https://typicode.github.io/husky/#/?id=custom-directory)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command
```

So I asked him to create a .git dir

> can you try mkdir -p $HOME/jellyseerr/.git and run the script again?

And it worked out just fine

> Done. Installed jellyseerr successfully.
> 
> Thanks a lot mate!!!  It was all due to that .git folder missing inside jellyseerr folder. How did you figure it out!!