### PR TITLE
Update jellyseerr source

### DIFF
--- a/jellyseerr.sh
+++ b/jellyseerr.sh
@@ -33,7 +33,7 @@ function _deps() {
 
 function _jellyseerr_install() {
     echo "Downloading and extracting source code"
-    dlurl="$(curl -sS https://api.github.com/repos/Fallenbagel/jellyseerr/releases/latest | jq .tarball_url -r)"
+    dlurl="$(curl -sS https://api.github.com/repositories/467856408/releases/latest | jq .tarball_url -r)"
     wget "$dlurl" -q -O /home/${user}/jellyseerr.tar.gz >> "$log" 2>&1 || {
         echo "Download failed"
         exit 1


### PR DESCRIPTION
`curl -sS https://api.github.com/repos/Fallenbagel/jellyseerr/releases/latest`

returns the fact that it has moved:

```
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/467856408/releases/latest",
  "documentation_url": "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
}
```

This might be what #51 was having an issue with.
